### PR TITLE
Fix CMakeLists for non-standard NLopt install location

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -98,6 +98,12 @@ if (HAVE_PTHREAD)
   set (EXTRA_LIBS ${EXTRA_LIBS} ${CMAKE_THREAD_LIBS_INIT})
 endif ()
 
+if (HAVE_NLOPT)
+  find_package (NLOPT REQUIRED)
+  set (EXTRA_LIBS ${EXTRA_LIBS} ${NLOPT_LIBRARIES})
+  include_directories (${NLOPT_INCLUDE_DIRS})
+endif ()
+
 target_link_libraries (neper ${EXTRA_LIBS})
 
 install (TARGETS neper DESTINATION bin

--- a/src/contrib/ut/CMakeLists.txt
+++ b/src/contrib/ut/CMakeLists.txt
@@ -75,6 +75,12 @@ if (HAVE_GSL)
   include_directories (${GSL_INCLUDE_DIRS})
 endif (HAVE_GSL)
 
+if (HAVE_NLOPT)
+  find_package (NLOPT REQUIRED)
+  set (EXTRA_LIBS ${EXTRA_LIBS} ${NLOPT_LIBRARIES})
+  include_directories (${NLOPT_INCLUDE_DIRS})
+endif ()
+
 target_link_libraries (ut ${EXTRA_LIBS})
 
 # Installation of the library


### PR DESCRIPTION
The added nlopt includes in CMakeLists.txt make it possible for cmake to create a Makefile that will properly include nlopt.h when nlopt hasn't been installed with a package manager.

This allows for installation of nlopt to a location like $HOME/.local and then allow neper to build from that installation.

Admittedly there were errors when I ran `make test` with the generated Makefile but I'm not sure if these are related to the changes I made. I will attach the errors and you can assess for yourself whether they are relevant to these changes.
Thanks.
[out.txt](https://github.com/rquey/neper/files/1120346/out.txt)
